### PR TITLE
Fix Math expression in `r` property caused by wrong unit detection.

### DIFF
--- a/src/parser/parse-compound-value.js
+++ b/src/parser/parse-compound-value.js
@@ -5,12 +5,16 @@ function parse(input) {
   let ret = {};
   let matched = false;
   while (iter.next()) {
-    let { prev, curr } = iter.get();
+    let { prev, curr, next} = iter.get();
+    let isUnit = matched
+      && (curr.isWord() || curr.isSymbol())
+      && prev && prev.isNumber()
+      && !next;
     if (curr.isNumber()) {
       ret.value = Number(curr.value);
       matched = true;
     }
-    else if (matched && (curr.isWord() || curr.isSymbol()) && prev && prev.isNumber()) {
+    else if (isUnit) {
       ret.unit = curr.value;
     } else {
       break;

--- a/test/parse-compound-value.js
+++ b/test/parse-compound-value.js
@@ -32,4 +32,13 @@ test('direction group', t => {
     unit: '%'
   });
 
+  // should be treated as expression
+  compare(t, '10%2', {
+    value: 10,
+  });
+
+  compare(t, '1/sin(t)', {
+    value: 1,
+  });
+
 });


### PR DESCRIPTION
```css
clip-path: @shape(

  /* failed to calc for complex r value */
  r: 1/sin(t);  

);
```