### PR TITLE
Reduce the default grid size to maximum 64x64

### DIFF
--- a/src/generator/css.js
+++ b/src/generator/css.js
@@ -89,7 +89,7 @@ class Rules {
       let type = typeof arg.value;
       let is_string_or_number = (type === 'number' || type === 'string');
       if (!arg.cluster && (is_string_or_number)) {
-        input.push(...parse_value_group(arg.value, true));
+        input.push(...parse_value_group(arg.value, { noSpace: true }));
       }
       else {
         if (typeof arg === 'function') {
@@ -402,6 +402,7 @@ class Rules {
       let transformed = Property[name](value, {
         is_special_selector: is_special_selector(selector),
         grid: coords.grid,
+        max_grid: coords.max_grid,
         extra
       });
       switch (name) {
@@ -413,7 +414,8 @@ class Rules {
             if (!this.is_grid_defined) {
               transformed = Property[name](value, {
                 is_special_selector: true,
-                grid: coords.grid
+                grid: coords.grid,
+                max_grid: coords.max_grid
               });
               this.add_rule(':host', transformed.size || '');
             }
@@ -459,7 +461,9 @@ class Rules {
         }, []);
         let value = value_group.join(', ');
         let name = prop.substr(1);
-        let transformed = Property[name](value, {});
+        let transformed = Property[name](value, {
+          max_grid: _coords.max_grid
+        });
         this.grid = transformed.grid;
         break;
       }
@@ -614,7 +618,7 @@ class Rules {
 
 }
 
-function generate_css(tokens, grid_size, random) {
+function generate_css(tokens, grid_size, random, max_grid) {
   let rules = new Rules(tokens);
   let context = {};
 
@@ -646,6 +650,7 @@ function generate_css(tokens, grid_size, random) {
     x: 1, y: 1, z: 1, count: 1, context: {},
     grid: { x: 1, y: 1, z: 1, count: 1 },
     random, rand, pick, shuffle,
+    max_grid,
   });
 
   let { grid } = rules.output();
@@ -659,6 +664,7 @@ function generate_css(tokens, grid_size, random) {
           x, y, z: 1,
           count: ++count, grid: grid_size, context,
           random, rand, pick, shuffle,
+          max_grid,
         });
       }
     }
@@ -669,6 +675,7 @@ function generate_css(tokens, grid_size, random) {
         x: 1, y: 1, z,
         count: ++count, grid: grid_size, context,
         random, rand, pick, shuffle,
+        max_grid,
       });
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -144,8 +144,12 @@ if (typeof customElements !== 'undefined') {
       this.connectedCallback(true);
     }
 
+    get_max_grid() {
+      return this.hasAttribute('experimental') ? 256 : 64;
+    }
+
     get_grid() {
-      return parse_grid(this.attr('grid'));
+      return parse_grid(this.attr('grid'), this.get_max_grid());
     }
 
     get_use() {
@@ -176,7 +180,7 @@ if (typeof customElements !== 'undefined') {
       this._seed_value = seed;
 
       let random = this.random = seedrandom(seed);
-      let compiled = this.compiled = generate_css(parsed, grid, random);
+      let compiled = this.compiled = generate_css(parsed, grid, random, this.get_max_grid());
       return compiled;
     }
 
@@ -187,8 +191,8 @@ if (typeof customElements !== 'undefined') {
       }
       code = ':doodle { width:100%;height:100% }' + code;
       let parsed = parse_css(code, this.extra);
-      let _grid = parse_grid({});
-      let compiled = generate_css(parsed, _grid, this.random);
+      let _grid = parse_grid('');
+      let compiled = generate_css(parsed, _grid, this.random, this.get_max_grid());
       let grid = compiled.grid ? compiled.grid : _grid;
       const { keyframes, host, container, cells } = compiled.styles;
 

--- a/src/parser/parse-grid.js
+++ b/src/parser/parse-grid.js
@@ -1,8 +1,8 @@
 import { clamp } from '../utils/index.js';
 
-const [ min, max, total ] = [ 1, 256, 256 * 256 ];
+export default function parse_grid(size, GRID = 64) {
+  const [min, max, total] = [1, GRID, GRID * GRID];
 
-export default function parse_grid(size) {
   let [x, y, z] = (size + '')
     .replace(/\s+/g, '')
     .replace(/[,，xX]+/g, 'x')

--- a/src/property.js
+++ b/src/property.js
@@ -65,10 +65,9 @@ export default add_alias({
   },
 
   grid(value, options) {
-    let [grid, ...size] = value.split('/').map(s => s.trim());
-    size = size.join(' / ');
+    let [grid, size] = parse_value_group(value, { symbol: '/', noSpace: true });
     return {
-      grid: parse_grid(grid),
+      grid: parse_grid(grid, options.max_grid),
       size: size ? this.size(size, options) : ''
     };
   },

--- a/test/parse-grid.js
+++ b/test/parse-grid.js
@@ -38,9 +38,9 @@ test('clamp value', t => {
 
   compare(t, '0x1', defaultGrid);
 
-  compare(t, '70000,1', { x: 65536, y: 1, z: 1, count: 65536, ratio: 65536 });
+  compare(t, '70000,1', { x: 4096, y: 1, z: 1, count: 4096, ratio: 4096 });
 
-  compare(t, '70000', { x: 256, y: 256, z: 1, count: 65536, ratio: 1 });
+  compare(t, '70000', { x: 64, y: 64, z: 1, count: 4096, ratio: 1 });
 
   compare(t, '0.5', defaultGrid);
 

--- a/test/parse-value-group.js
+++ b/test/parse-value-group.js
@@ -39,7 +39,7 @@ test('basic value group', t => {
 test('no space option', t => {
 
   compare.use(input => {
-    return parseValueGroup(input, true);
+    return parseValueGroup(input, { noSpace: true });
   });
 
   compare(t, 'a b', ['a b']);
@@ -53,3 +53,21 @@ test('no space option', t => {
   compare(t, 'a, b', ['a', 'b']);
 
 });
+
+
+test('grid value', t => {
+
+  compare.use(input => {
+    return parseValueGroup(input, { symbol: '/', noSpace: true });
+  });
+
+  compare(t, '5 / 100%', ['5', '100%']);
+
+  compare(t, '5/100%', ['5', '100%']);
+
+  compare(t, '5 / calc(100% / 5)', ['5', 'calc(100% / 5)']);
+
+  compare(t, '5x10 / @r(100px)', ['5x10', '@r(100px)']);
+
+});
+


### PR DESCRIPTION
It can be up to `256x256` only if a `experimental` attribute is provided

```html
<!-- 64x64 -->
<css-doodle grid="100"></css-doodle>

<!-- 100x100 -->
<css-doodle grid="100" experimental></css-doodle>
```

## Why 

1. Users who are new to `css-doodle` tend to test different values around. The browser will freeze if the grid size is too big, which will discourage them to try and experiment further.

2. It's hard to type `400x1` in a live editor, since the first `400` will generate a `256x256` grid. Browser freezes.

3. Sometimes the limitation will stimulate creativity.
